### PR TITLE
fix .tar.xz support

### DIFF
--- a/gh-install
+++ b/gh-install
@@ -25,7 +25,7 @@ extract () {
             case $arg in
                 *.tar.bz2)  tar xjf $arg      ;;
                 *.tar.gz)   tar xzf $arg      ;;
-                *.tar.xz)   tar xJf $arg      ;;
+                *.tar.xz)   tar xf $arg       ;;
                 *.bz2)      bunzip2 $arg      ;;
                 *.gz)       gunzip $arg       ;;
                 *.tar)      tar xf $arg       ;;

--- a/gh-install
+++ b/gh-install
@@ -25,7 +25,7 @@ extract () {
             case $arg in
                 *.tar.bz2)  tar xjf $arg      ;;
                 *.tar.gz)   tar xzf $arg      ;;
-                *.tar.xz)   tar xzf $arg      ;;
+                *.tar.xz)   tar xJf $arg      ;;
                 *.bz2)      bunzip2 $arg      ;;
                 *.gz)       gunzip $arg       ;;
                 *.tar)      tar xf $arg       ;;


### PR DESCRIPTION
tar uses -J for `.tar.xz` files (I feel like catching this somewhat vindicates my suspicion of concatenated short unix options :shrug:)


In my case, tested with 


```shell
./gh-install brettcannon/python-launcher
```