### PR TITLE
Update gh-install to support *.tar.zst

### DIFF
--- a/gh-install
+++ b/gh-install
@@ -26,6 +26,7 @@ extract () {
                 *.tar.bz2)  tar xjf $arg      ;;
                 *.tar.gz)   tar xzf $arg      ;;
                 *.tar.xz)   tar xf $arg       ;;
+                *.tar.zst)  tar xf $arg       ;;
                 *.bz2)      bunzip2 $arg      ;;
                 *.gz)       gunzip $arg       ;;
                 *.tar)      tar xf $arg       ;;


### PR DESCRIPTION
This can be extracted simply with `tar -xf`.
Example repository using this release artifact format is microsoft/edit.

Fixing #9 