### PR TITLE
Use mktemp to create temporary directory

### DIFF
--- a/gh-install
+++ b/gh-install
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
-TMP="/tmp/.gh-install"
+TMP=$(mktemp -d gh-install.XXXXXX --tmpdir)
 BINPATH="${GH_BINPATH:-$HOME/.local/bin}"
 REPO=$1
 


### PR DESCRIPTION
`/tmp` doesn't exist on some esoteric systems, or isn't accessible 